### PR TITLE
Adding aws-sdk-v1 to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in capify-v3-ec2.gemspec
 gemspec
+gem 'aws-sdk-v1'


### PR DESCRIPTION
The aws-sdk v1 gem is required by some parts of this gem, so putting it in the Gemfile will allow bundler to pull it recursively instead of needing to include it in upstream Gemfiles